### PR TITLE
use seq<_> for more model description items

### DIFF
--- a/Elmish.XamarinForms/DynamicViewHelpers.fs
+++ b/Elmish.XamarinForms/DynamicViewHelpers.fs
@@ -23,7 +23,7 @@ module SimplerHelpers =
         let children = els |> List.mapi (fun i x -> x.GridColumn i)
         Xaml.Grid(coldefs=cds, children=children)
 
-    type internal Amortizations() = 
+    type internal Memoizations() = 
        static let t = Dictionary<obj,System.WeakReference<obj>>(HashIdentity.Structural)
        static member T = t
 
@@ -38,11 +38,11 @@ module SimplerHelpers =
     let dependsOn key (f: DoNotUseModelInsideDependsOn -> 'Key -> 'Value) : 'Value = 
         let bkey = (key, f.GetType())
         let mutable res = null
-        match Amortizations.T.TryGetValue(bkey) with 
+        match Memoizations.T.TryGetValue(bkey) with 
         | true, weak when weak.TryGetTarget(&res) -> unbox res
         | _ ->
              let res = f DoNotUseModelInsideDependsOn key
-             Amortizations.T.[bkey] <- System.WeakReference<obj>(box res)
+             Memoizations.T.[bkey] <- System.WeakReference<obj>(box res)
              res
         
     /// Memoize a callback that has no interesting dependencies.
@@ -50,26 +50,26 @@ module SimplerHelpers =
     let fix (f: unit -> 'Value) = 
         let key = f.GetType()
         let mutable res = null
-        match Amortizations.T.TryGetValue(key) with 
+        match Memoizations.T.TryGetValue(key) with 
         | true, weak when weak.TryGetTarget(&res) -> unbox res
         | _ ->
              // Note: we do this check once only per syntactic closure occurrence that is passed to 'fix'
              let flds = key.GetFields(System.Reflection.BindingFlags.NonPublic) |> Array.filter (fun fld -> fld.Name <> "dispatch")
              if flds.Length > 0 then failwithf "the closure '%s' has a dependency '%s', you can't use 'fix' with such a closure" key.Name flds.[0].Name
              let res = f()
-             Amortizations.T.[key] <- System.WeakReference<obj>(box res)
+             Memoizations.T.[key] <- System.WeakReference<obj>(box res)
              res
 
     let fixf (f: 'Args -> 'Value) = 
         let key = f.GetType()
         let mutable res = null
-        match Amortizations.T.TryGetValue(key) with 
+        match Memoizations.T.TryGetValue(key) with 
         | true, weak when weak.TryGetTarget(&res) -> unbox res
         | _ ->
              // Note: we do this check once only per syntactic closure occurrence that is passed to 'fix'
              let flds = key.GetFields(System.Reflection.BindingFlags.NonPublic) |> Array.filter (fun fld -> fld.Name <> "dispatch")
              if flds.Length > 0 then failwithf "the closure '%s' has a dependency '%s', you can't use 'fix' with such a closure" key.Name flds.[0].Name
              let res = f
-             Amortizations.T.[key] <- System.WeakReference<obj>(box res)
+             Memoizations.T.[key] <- System.WeakReference<obj>(box res)
              res
         

--- a/Elmish.XamarinForms/DynamicXaml.fs
+++ b/Elmish.XamarinForms/DynamicXaml.fs
@@ -672,12 +672,6 @@ module XamlElementExtensions =
         /// Try to get the UseSafeArea property in the visual element
         member x.TryUseSafeArea = match x.Attributes.TryFind("UseSafeArea") with Some v -> USome(unbox<bool>(v)) | None -> UNone
 
-        /// Try to get the ItemsSource property in the visual element
-        member x.TryItemsSource = match x.Attributes.TryFind("ItemsSource") with Some v -> USome(unbox<System.Collections.Generic.IList<obj>>(v)) | None -> UNone
-
-        /// Try to get the ItemTemplate property in the visual element
-        member x.TryItemTemplate = match x.Attributes.TryFind("ItemTemplate") with Some v -> USome(unbox<Xamarin.Forms.DataTemplate>(v)) | None -> UNone
-
         /// Try to get the CarouselPage_SelectedItem property in the visual element
         member x.TryCarouselPage_SelectedItem = match x.Attributes.TryFind("CarouselPage_SelectedItem") with Some v -> USome(unbox<System.Object>(v)) | None -> UNone
 
@@ -757,7 +751,7 @@ module XamlElementExtensions =
         member x.TryView = match x.Attributes.TryFind("View") with Some v -> USome(unbox<XamlElement>(v)) | None -> UNone
 
         /// Try to get the ListViewItems property in the visual element
-        member x.TryListViewItems = match x.Attributes.TryFind("ListViewItems") with Some v -> USome(unbox<XamlElement[]>(v)) | None -> UNone
+        member x.TryListViewItems = match x.Attributes.TryFind("ListViewItems") with Some v -> USome(unbox<seq<XamlElement>>(v)) | None -> UNone
 
         /// Try to get the Footer property in the visual element
         member x.TryFooter = match x.Attributes.TryFind("Footer") with Some v -> USome(unbox<System.Object>(v)) | None -> UNone
@@ -1087,7 +1081,7 @@ module XamlElementExtensions =
         member x.DateSelected(value: Xamarin.Forms.DateChangedEventArgs -> unit) = XamlElement(x.TargetType, x.CreateMethod, x.UpdateMethod, x.Attributes.Add("DateSelected", box ((fun f -> System.EventHandler<Xamarin.Forms.DateChangedEventArgs>(fun _sender args -> f args))(value))))
 
         /// Adjusts the PickerItemsSource property in the visual element
-        member x.PickerItemsSource(value: 'T list) = XamlElement(x.TargetType, x.CreateMethod, x.UpdateMethod, x.Attributes.Add("PickerItemsSource", box ((fun es -> es |> Array.ofList :> System.Collections.IList)(value))))
+        member x.PickerItemsSource(value: seq<'T>) = XamlElement(x.TargetType, x.CreateMethod, x.UpdateMethod, x.Attributes.Add("PickerItemsSource", box (seqToIList(value))))
 
         /// Adjusts the SelectedIndex property in the visual element
         member x.SelectedIndex(value: int) = XamlElement(x.TargetType, x.CreateMethod, x.UpdateMethod, x.Attributes.Add("SelectedIndex", box ((value))))
@@ -1170,12 +1164,6 @@ module XamlElementExtensions =
         /// Adjusts the UseSafeArea property in the visual element
         member x.UseSafeArea(value: bool) = XamlElement(x.TargetType, x.CreateMethod, x.UpdateMethod, x.Attributes.Add("UseSafeArea", box ((value))))
 
-        /// Adjusts the ItemsSource property in the visual element
-        member x.ItemsSource(value: 'T list) = XamlElement(x.TargetType, x.CreateMethod, x.UpdateMethod, x.Attributes.Add("ItemsSource", box ((fun es -> es |> Array.ofList |> Array.map box :> System.Collections.Generic.IList<obj>)(value))))
-
-        /// Adjusts the ItemTemplate property in the visual element
-        member x.ItemTemplate(value: Xamarin.Forms.DataTemplate) = XamlElement(x.TargetType, x.CreateMethod, x.UpdateMethod, x.Attributes.Add("ItemTemplate", box ((value))))
-
         /// Adjusts the CarouselPage_SelectedItem property in the visual element
         member x.CarouselPage_SelectedItem(value: System.Object) = XamlElement(x.TargetType, x.CreateMethod, x.UpdateMethod, x.Attributes.Add("CarouselPage_SelectedItem", box ((value))))
 
@@ -1255,7 +1243,7 @@ module XamlElementExtensions =
         member x.View(value: XamlElement) = XamlElement(x.TargetType, x.CreateMethod, x.UpdateMethod, x.Attributes.Add("View", box ((value))))
 
         /// Adjusts the ListViewItems property in the visual element
-        member x.ListViewItems(value: XamlElement list) = XamlElement(x.TargetType, x.CreateMethod, x.UpdateMethod, x.Attributes.Add("ListViewItems", box (Array.ofList(value))))
+        member x.ListViewItems(value: seq<XamlElement>) = XamlElement(x.TargetType, x.CreateMethod, x.UpdateMethod, x.Attributes.Add("ListViewItems", box ((value))))
 
         /// Adjusts the Footer property in the visual element
         member x.Footer(value: System.Object) = XamlElement(x.TargetType, x.CreateMethod, x.UpdateMethod, x.Attributes.Add("Footer", box ((value))))
@@ -1859,10 +1847,10 @@ module XamlElementExtensions =
     let dateSelected (value: Xamarin.Forms.DateChangedEventArgs -> unit) (x: XamlElement) = x.DateSelected(value)
 
     /// Adjusts the PickerItemsSource property in the visual element
-    let withPickerItemsSource (value: 'T list) (x: XamlElement) = x.PickerItemsSource(value)
+    let withPickerItemsSource (value: seq<'T>) (x: XamlElement) = x.PickerItemsSource(value)
 
     /// Adjusts the PickerItemsSource property in the visual element
-    let pickerItemsSource (value: 'T list) (x: XamlElement) = x.PickerItemsSource(value)
+    let pickerItemsSource (value: seq<'T>) (x: XamlElement) = x.PickerItemsSource(value)
 
     /// Adjusts the SelectedIndex property in the visual element
     let withSelectedIndex (value: int) (x: XamlElement) = x.SelectedIndex(value)
@@ -2026,18 +2014,6 @@ module XamlElementExtensions =
     /// Adjusts the UseSafeArea property in the visual element
     let useSafeArea (value: bool) (x: XamlElement) = x.UseSafeArea(value)
 
-    /// Adjusts the ItemsSource property in the visual element
-    let withItemsSource (value: 'T list) (x: XamlElement) = x.ItemsSource(value)
-
-    /// Adjusts the ItemsSource property in the visual element
-    let itemsSource (value: 'T list) (x: XamlElement) = x.ItemsSource(value)
-
-    /// Adjusts the ItemTemplate property in the visual element
-    let withItemTemplate (value: Xamarin.Forms.DataTemplate) (x: XamlElement) = x.ItemTemplate(value)
-
-    /// Adjusts the ItemTemplate property in the visual element
-    let itemTemplate (value: Xamarin.Forms.DataTemplate) (x: XamlElement) = x.ItemTemplate(value)
-
     /// Adjusts the CarouselPage_SelectedItem property in the visual element
     let withCarouselPage_SelectedItem (value: System.Object) (x: XamlElement) = x.CarouselPage_SelectedItem(value)
 
@@ -2195,10 +2171,10 @@ module XamlElementExtensions =
     let view (value: XamlElement) (x: XamlElement) = x.View(value)
 
     /// Adjusts the ListViewItems property in the visual element
-    let withListViewItems (value: XamlElement list) (x: XamlElement) = x.ListViewItems(value)
+    let withListViewItems (value: seq<XamlElement>) (x: XamlElement) = x.ListViewItems(value)
 
     /// Adjusts the ListViewItems property in the visual element
-    let listViewItems (value: XamlElement list) (x: XamlElement) = x.ListViewItems(value)
+    let listViewItems (value: seq<XamlElement>) (x: XamlElement) = x.ListViewItems(value)
 
     /// Adjusts the Footer property in the visual element
     let withFooter (value: System.Object) (x: XamlElement) = x.Footer(value)
@@ -6871,9 +6847,9 @@ type Xaml() =
         new XamlElement(typeof<Xamarin.Forms.DatePicker>, create, update, Map.ofArray attribs)
 
     /// Describes a Picker in the view
-    static member Picker(?itemsSource: 'T list, ?selectedIndex: int, ?title: string, ?textColor: Xamarin.Forms.Color, ?selectedIndexChanged: (int * 'T option) -> unit, ?horizontalOptions: Xamarin.Forms.LayoutOptions, ?verticalOptions: Xamarin.Forms.LayoutOptions, ?margin: obj, ?gestureRecognizers: XamlElement list, ?anchorX: double, ?anchorY: double, ?backgroundColor: Xamarin.Forms.Color, ?heightRequest: double, ?inputTransparent: bool, ?isEnabled: bool, ?isVisible: bool, ?minimumHeightRequest: double, ?minimumWidthRequest: double, ?opacity: double, ?rotation: double, ?rotationX: double, ?rotationY: double, ?scale: double, ?style: Xamarin.Forms.Style, ?translationX: double, ?translationY: double, ?widthRequest: double, ?classId: string, ?styleId: string) = 
+    static member Picker(?itemsSource: seq<'T>, ?selectedIndex: int, ?title: string, ?textColor: Xamarin.Forms.Color, ?selectedIndexChanged: (int * 'T option) -> unit, ?horizontalOptions: Xamarin.Forms.LayoutOptions, ?verticalOptions: Xamarin.Forms.LayoutOptions, ?margin: obj, ?gestureRecognizers: XamlElement list, ?anchorX: double, ?anchorY: double, ?backgroundColor: Xamarin.Forms.Color, ?heightRequest: double, ?inputTransparent: bool, ?isEnabled: bool, ?isVisible: bool, ?minimumHeightRequest: double, ?minimumWidthRequest: double, ?opacity: double, ?rotation: double, ?rotationX: double, ?rotationY: double, ?scale: double, ?style: Xamarin.Forms.Style, ?translationX: double, ?translationY: double, ?widthRequest: double, ?classId: string, ?styleId: string) = 
         let attribs = [| 
-            match itemsSource with None -> () | Some v -> yield ("PickerItemsSource", box ((fun es -> es |> Array.ofList :> System.Collections.IList)(v))) 
+            match itemsSource with None -> () | Some v -> yield ("PickerItemsSource", box (seqToIList(v))) 
             match selectedIndex with None -> () | Some v -> yield ("SelectedIndex", box ((v))) 
             match title with None -> () | Some v -> yield ("Title", box ((v))) 
             match textColor with None -> () | Some v -> yield ("TextColor", box ((v))) 
@@ -9900,11 +9876,9 @@ type Xaml() =
         new XamlElement(typeof<Xamarin.Forms.Page>, create, update, Map.ofArray attribs)
 
     /// Describes a CarouselPage in the view
-    static member CarouselPage(?children: XamlElement list, ?itemsSource: 'T list, ?itemTemplate: Xamarin.Forms.DataTemplate, ?selectedItem: System.Object, ?currentPage: XamlElement, ?currentPageChanged: 'T option -> unit, ?title: string, ?padding: obj, ?useSafeArea: bool, ?anchorX: double, ?anchorY: double, ?backgroundColor: Xamarin.Forms.Color, ?heightRequest: double, ?inputTransparent: bool, ?isEnabled: bool, ?isVisible: bool, ?minimumHeightRequest: double, ?minimumWidthRequest: double, ?opacity: double, ?rotation: double, ?rotationX: double, ?rotationY: double, ?scale: double, ?style: Xamarin.Forms.Style, ?translationX: double, ?translationY: double, ?widthRequest: double, ?classId: string, ?styleId: string) = 
+    static member CarouselPage(?children: XamlElement list, ?selectedItem: System.Object, ?currentPage: XamlElement, ?currentPageChanged: 'T option -> unit, ?title: string, ?padding: obj, ?useSafeArea: bool, ?anchorX: double, ?anchorY: double, ?backgroundColor: Xamarin.Forms.Color, ?heightRequest: double, ?inputTransparent: bool, ?isEnabled: bool, ?isVisible: bool, ?minimumHeightRequest: double, ?minimumWidthRequest: double, ?opacity: double, ?rotation: double, ?rotationX: double, ?rotationY: double, ?scale: double, ?style: Xamarin.Forms.Style, ?translationX: double, ?translationY: double, ?widthRequest: double, ?classId: string, ?styleId: string) = 
         let attribs = [| 
             match children with None -> () | Some v -> yield ("Children", box (Array.ofList(v))) 
-            match itemsSource with None -> () | Some v -> yield ("ItemsSource", box ((fun es -> es |> Array.ofList |> Array.map box :> System.Collections.Generic.IList<obj>)(v))) 
-            match itemTemplate with None -> () | Some v -> yield ("ItemTemplate", box ((v))) 
             match selectedItem with None -> () | Some v -> yield ("CarouselPage_SelectedItem", box ((v))) 
             match currentPage with None -> () | Some v -> yield ("CurrentPage", box ((v))) 
             match currentPageChanged with None -> () | Some v -> yield ("CurrentPageChanged", box ((fun f -> System.EventHandler(fun sender args -> f ((sender :?> Xamarin.Forms.CarouselPage).SelectedItem |> Option.ofObj |> Option.map unbox<'T>)))(v))) 
@@ -9944,20 +9918,6 @@ type Xaml() =
                 (fun _ _ _ -> ())
                 canReuseDefault
                 updateDefault
-            let prevValueOpt = match prevOpt with UNone -> UNone | USome prev -> prev.TryItemsSource
-            let valueOpt = source.TryItemsSource
-            match prevValueOpt, valueOpt with
-            | USome prevValue, USome value when prevValue = value -> ()
-            | prevOpt, USome value -> System.Diagnostics.Debug.WriteLine("Setting CarouselPage::ItemsSource "); target.ItemsSource <-  value
-            | USome _, UNone -> target.ItemsSource <- null
-            | UNone, UNone -> ()
-            let prevValueOpt = match prevOpt with UNone -> UNone | USome prev -> prev.TryItemTemplate
-            let valueOpt = source.TryItemTemplate
-            match prevValueOpt, valueOpt with
-            | USome prevValue, USome value when prevValue = value -> ()
-            | prevOpt, USome value -> System.Diagnostics.Debug.WriteLine("Setting CarouselPage::ItemTemplate "); target.ItemTemplate <-  value
-            | USome _, UNone -> target.ItemTemplate <- null
-            | UNone, UNone -> ()
             let prevValueOpt = match prevOpt with UNone -> UNone | USome prev -> prev.TryCarouselPage_SelectedItem
             let valueOpt = source.TryCarouselPage_SelectedItem
             match prevValueOpt, valueOpt with
@@ -11367,9 +11327,9 @@ type Xaml() =
         new XamlElement(typeof<Xamarin.Forms.ViewCell>, create, update, Map.ofArray attribs)
 
     /// Describes a ListView in the view
-    static member ListView(?items: XamlElement list, ?footer: System.Object, ?hasUnevenRows: bool, ?header: System.Object, ?headerTemplate: Xamarin.Forms.DataTemplate, ?isGroupingEnabled: bool, ?isPullToRefreshEnabled: bool, ?isRefreshing: bool, ?refreshCommand: unit -> unit, ?rowHeight: int, ?selectedItem: int option, ?separatorVisibility: Xamarin.Forms.SeparatorVisibility, ?separatorColor: Xamarin.Forms.Color, ?itemAppearing: int -> unit, ?itemDisappearing: int -> unit, ?itemSelected: int option -> unit, ?itemTapped: Xamarin.Forms.ItemTappedEventArgs -> unit, ?refreshing: unit -> unit, ?horizontalOptions: Xamarin.Forms.LayoutOptions, ?verticalOptions: Xamarin.Forms.LayoutOptions, ?margin: obj, ?gestureRecognizers: XamlElement list, ?anchorX: double, ?anchorY: double, ?backgroundColor: Xamarin.Forms.Color, ?heightRequest: double, ?inputTransparent: bool, ?isEnabled: bool, ?isVisible: bool, ?minimumHeightRequest: double, ?minimumWidthRequest: double, ?opacity: double, ?rotation: double, ?rotationX: double, ?rotationY: double, ?scale: double, ?style: Xamarin.Forms.Style, ?translationX: double, ?translationY: double, ?widthRequest: double, ?classId: string, ?styleId: string) = 
+    static member ListView(?items: seq<XamlElement>, ?footer: System.Object, ?hasUnevenRows: bool, ?header: System.Object, ?headerTemplate: Xamarin.Forms.DataTemplate, ?isGroupingEnabled: bool, ?isPullToRefreshEnabled: bool, ?isRefreshing: bool, ?refreshCommand: unit -> unit, ?rowHeight: int, ?selectedItem: int option, ?separatorVisibility: Xamarin.Forms.SeparatorVisibility, ?separatorColor: Xamarin.Forms.Color, ?itemAppearing: int -> unit, ?itemDisappearing: int -> unit, ?itemSelected: int option -> unit, ?itemTapped: Xamarin.Forms.ItemTappedEventArgs -> unit, ?refreshing: unit -> unit, ?horizontalOptions: Xamarin.Forms.LayoutOptions, ?verticalOptions: Xamarin.Forms.LayoutOptions, ?margin: obj, ?gestureRecognizers: XamlElement list, ?anchorX: double, ?anchorY: double, ?backgroundColor: Xamarin.Forms.Color, ?heightRequest: double, ?inputTransparent: bool, ?isEnabled: bool, ?isVisible: bool, ?minimumHeightRequest: double, ?minimumWidthRequest: double, ?opacity: double, ?rotation: double, ?rotationX: double, ?rotationY: double, ?scale: double, ?style: Xamarin.Forms.Style, ?translationX: double, ?translationY: double, ?widthRequest: double, ?classId: string, ?styleId: string) = 
         let attribs = [| 
-            match items with None -> () | Some v -> yield ("ListViewItems", box (Array.ofList(v))) 
+            match items with None -> () | Some v -> yield ("ListViewItems", box ((v))) 
             match footer with None -> () | Some v -> yield ("Footer", box ((v))) 
             match hasUnevenRows with None -> () | Some v -> yield ("HasUnevenRows", box ((v))) 
             match header with None -> () | Some v -> yield ("Header", box ((v))) 

--- a/Generator/bindings.json
+++ b/Generator/bindings.json
@@ -689,9 +689,9 @@
 				{
 					"name": "ItemsSource",
 					"uniqueName": "PickerItemsSource",
-					"inputType": "'T list",
+					"inputType": "seq<'T>",
 					"modelType": "System.Collections.IList",
-					"convToModel": "(fun es -> es |> Array.ofList :> System.Collections.IList)",
+					"convToModel": "seqToIList",
 					"defaultValue": "null"
 				},
 				{
@@ -1076,17 +1076,17 @@
 					"modelType": "XamlElement[]",
 					"convToModel": "Array.ofList"
 				},
-				{
-					"name": "ItemsSource",
-					"inputType": "'T list",
-					"modelType": "System.Collections.Generic.IList<obj>",
-					"convToModel": "(fun es -> es |> Array.ofList |> Array.map box :> System.Collections.Generic.IList<obj>)",
-					"defaultValue": "null"
-				},
-				{
-					"name": "ItemTemplate",
-					"defaultValue": "null"
-				},
+				//{
+			//		"name": "ItemsSource",
+			//		"inputType": "'T list",
+		//			"modelType": "System.Collections.Generic.IList<obj>",
+		//			"convToModel": "(fun es -> es |> Array.ofList |> Array.map box :> System.Collections.Generic.IList<obj>)",
+		//			"defaultValue": "null"
+		//		},
+		//		{
+		//			"name": "ItemTemplate",
+		//			"defaultValue": "null"
+		//		},
 				{
 					"name": "SelectedItem",
 					"uniqueName": "CarouselPage_SelectedItem",
@@ -1321,9 +1321,8 @@
 					"name": "ItemsSource",
 					"uniqueName": "ListViewItems",
 					"shortName": "items",
-					"inputType": "XamlElement list",
-					"modelType": "XamlElement[]",
-					"convToModel": "Array.ofList",
+					"inputType": "seq<XamlElement>",
+					"modelType": "seq<XamlElement>",
 					"updateCode": "updateListViewItems"
 				},
 				//{

--- a/Samples/CounterApp/CounterApp/CounterApp.fs
+++ b/Samples/CounterApp/CounterApp/CounterApp.fs
@@ -1,9 +1,7 @@
 ﻿// Copyright 2018 Elmish.XamarinForms contributors. See LICENSE.md for license.
 namespace CounterApp
 
-open System
 open System.Diagnostics
-open Elmish
 open Elmish.XamarinForms
 open Elmish.XamarinForms.DynamicViews
 open Xamarin.Forms
@@ -61,8 +59,6 @@ module App =
               yield Xaml.Button(text="Reset", horizontalOptions=LayoutOptions.Center, command=fixf(fun () -> dispatch Reset), canExecute = (model <> initModel))
             ]))
 
-open App
-
 type CounterApp () as app = 
     inherit Application ()
 
@@ -97,30 +93,4 @@ type CounterApp () as app =
 
     override this.OnStart() = this.OnResume()
 
-#endif
-
-#if SAVE_MODEL_BIT_BY_BIT
-    let modelId = "model"
-    override __.OnSleep() = 
-        Debug.WriteLine "OnSleep: saving model into app.Properties"
-        app.Properties.["count"] <- runner.Model.Count
-        app.Properties.["step"] <- runner.Model.Step
-        app.Properties.["timerOn"] <- runner.Model.TimerOn
-
-    override __.OnResume() = 
-        Debug.WriteLine "OnResume: checking for model in app.Properties"
-        try 
-            match app.Properties.TryGetValue("count"),
-                  app.Properties.TryGetValue("step"),
-                  app.Properties.TryGetValue("timerOn") with
-            | (true, (:? int32 as count)), (true, (:? int32 as step)), (true, (:? bool as timerOn)) -> 
-                Debug.WriteLine "OnResume: restored model from app.Properties"
-                runner.Model <- { Count=count; Step=step; TimerOn=timerOn }
-            | _ -> 
-                Debug.WriteLine "OnResume: no model found to restore from app.Properties"
-                ()
-        with ex -> 
-            program.onError("Error while restoring model found in app.Properties", ex)
-
-    override this.OnStart() = this.OnResume()
 #endif


### PR DESCRIPTION

A few additional minor tweaks. We will gradually move to use `seq<_>` as the input type to allow a broader range of interesting collection specifications that support different diffing strategies