### PR TITLE
Fix duplicate key ArgumentException in the Interpreter

### DIFF
--- a/fscd/Interpreter.fs
+++ b/fscd/Interpreter.fs
@@ -385,7 +385,7 @@ type EvalContext ()  =
                 let paramTypes = membDef.Parameters |> Array.map (fun p -> p.Type)
                 let paramTypesR = ctxt.ResolveTypes(env, paramTypes)
                 let thunk = ctxt.EvalMethodLambda (envEmpty, (membDef.Name = ".ctor"), membDef.IsInstance, membDef.GenericParameters, membDef.Parameters, body)
-                members.Add((ty, membDef.Name, paramTypesR), Value thunk) 
+                members.[(ty, membDef.Name, paramTypesR)] <- Value thunk
             | _ -> ()
 
     member ctxt.EvalMethodLambda(env, isCtor, isInstance, typeParameters, parameters: DLocalDef[], body) = 


### PR DESCRIPTION
I was seeing the following exception

```
System.ArgumentException: An item with the same key has already been added. Key: (UEntity {Name = "CounterApp.App+Model";
         GenericParameters = [||];
         UnionCases = [||];}, CompareTo, UTypes [|UNamedType ({Name = "CounterApp.App+Model";
                      GenericParameters = [||];
                      UnionCases = [||];},[||])|])
```