### PR TITLE
Extensions - Fixed namespaces by extending the correct View class

### DIFF
--- a/docs/views-extending.md
+++ b/docs/views-extending.md
@@ -44,7 +44,9 @@ module MyViewExtensions =
     let Prop1AttribKey = AttributeKey<seq<ViewElement>> "ABC_Prop1"
     let Prop2AttribKey = AttributeKey<bool> "ABC_Prop2"
 
-    type View with
+    // Fully-qualified name to avoid extending by mistake
+    // another View class (like Xamarin.Forms.View)
+    type Elmish.XamarinForms.DynamicViews.View with
         /// Describes a ABC in the view
         static member ABC(?prop1: seq<ViewElement>, ?prop2: bool, ... inherited attributes ... ) =
 
@@ -126,7 +128,7 @@ module MapsExtension =
     let PinTypeAttribKey = AttributeKey "Pin_PinType"
     let PinAddressAttribKey = AttributeKey "Pin_Address"
 
-    type View with
+    type Elmish.XamarinForms.DynamicViews.View with
         /// Describes a Map in the view
         static member inline Map(?pins: seq<ViewElement>, ?isShowingUser: bool, ?mapType: MapType,
                                  ?hasScrollEnabled: bool, ?hasZoomEnabled: bool, ?requestedRegion: MapSpan,

--- a/docs/views-maps.md
+++ b/docs/views-maps.md
@@ -23,7 +23,7 @@ After these steps you can use maps in your `view` function as follows:
 
 ```fsharp
 open Xamarin.Forms.Maps
-open Elmish.XamarinForms
+open Elmish.XamarinForms.DynamicViews
 
 View.Map(hasZoomEnabled = true, hasScrollEnabled = true)
 ```

--- a/extensions/Maps/Xamarin.Forms.Maps.fs
+++ b/extensions/Maps/Xamarin.Forms.Maps.fs
@@ -21,7 +21,7 @@ module MapsExtension =
     let PinTypeAttribKey = AttributeKey "Pin_PinType"
     let PinAddressAttribKey = AttributeKey "Pin_Address"
 
-    type View with
+    type Elmish.XamarinForms.DynamicViews.View with
         /// Describes a Map in the view
         static member inline Map(?pins: seq<ViewElement>, ?isShowingUser: bool, ?mapType: MapType, ?hasScrollEnabled: bool,
                                  ?hasZoomEnabled: bool, ?requestedRegion: MapSpan,

--- a/extensions/OxyPlot/OxyPlot.fs
+++ b/extensions/OxyPlot/OxyPlot.fs
@@ -15,7 +15,7 @@ module OxyPlotExtension =
     let ModelAttribKey = AttributeKey<_> "OxyPlot_Model"
     let ControllerAttribKey = AttributeKey<_> "OxyPlot_Controller"
 
-    type View with
+    type Elmish.XamarinForms.DynamicViews.View with
         /// Describes a Map in the view
         static member inline PlotView
             (model: PlotModel, ?controller: PlotController, 

--- a/extensions/SkiaSharp/SkiaSharp.fs
+++ b/extensions/SkiaSharp/SkiaSharp.fs
@@ -15,7 +15,7 @@ module MapsExtension =
     let PaintSurfaceAttribKey = AttributeKey<_> "SKCanvas_PaintSurface"
     let TouchAttribKey = AttributeKey<_> "SKCanvas_Touch"
 
-    type View with
+    type Elmish.XamarinForms.DynamicViews.View with
         /// Describes a Map in the view
         static member SKCanvasView(?paintSurface: (SKPaintSurfaceEventArgs -> unit), ?touch: (SKTouchEventArgs -> unit), ?enableTouchEvents: bool, ?ignorePixelScaling: bool,
                                    // inherited attributes common to all views


### PR DESCRIPTION
The extensions open both `Elmish.XamarinForms.DynamicViews` and `Xamarin.Forms`.
As both have a `View` class, the latest namespace opened was selected for extending with `type View with`.
This resulted in a wrong namespace for `View.Map` and `View.SKCanvasView`.

```fsharp
open Xamarin.Forms
View.Map()
```
Instead of
```fsharp
open Elmish.XamarinForms.DynamicViews
View.Map()
```

I fixed it by fully qualifying the `View` class.
I could have just inverted the open statements, but figured it would be asking for trouble later.

Made it clear in the docs as well.