### PR TITLE
Added DisplayAlert and DisplayActionSheet

### DIFF
--- a/Elmish.XamarinForms/ViewHelpers.fs
+++ b/Elmish.XamarinForms/ViewHelpers.fs
@@ -172,3 +172,12 @@ module SimplerHelpers =
                 externalsTable.Add(externalObj, res)
                 res
 
+    type View with
+        static member displayAlert title message cancel =
+            Application.Current.MainPage.DisplayAlert(title, message, cancel) |> Async.AwaitTask
+
+        static member displayAlertWithConfirm title message accept cancel =
+            Application.Current.MainPage.DisplayAlert(title, message, accept, cancel) |> Async.AwaitTask
+            
+        static member displayActionSheet title cancel destruction buttons =
+            Application.Current.MainPage.DisplayActionSheet(title, cancel, destruction, buttons) |> Async.AwaitTask

--- a/Samples/AllControls/AllControls/AllControls.fs
+++ b/Samples/AllControls/AllControls/AllControls.fs
@@ -81,6 +81,7 @@ type Msg =
     // For InfiniteScroll page demo. It's not really an "infinite" scroll, just a growing set of "data"
     | SetInfiniteScrollMaxIndex of int
     | ExecuteSearch of string
+    | ShowMessage
 
 [<AutoOpen>]
 module MyExtension = 
@@ -198,6 +199,9 @@ module App =
         // For selection page
         | SetRootPageKind kind -> { model with RootPageKind = kind }
         | ExecuteSearch search -> { model with SearchTerm = search }
+        | ShowMessage ->
+            View.displayAlert "Clicked" "You clicked the button" "OK" |> ignore
+            model
 
     let pickerItems = 
         [| ("Aqua", Color.Aqua); ("Black", Color.Black);
@@ -226,6 +230,7 @@ module App =
                                  View.Button(text = "NavigationPage with push/pop", command=(fun () -> dispatch (SetRootPageKind Navigation)))
                                  View.Button(text = "MasterDetail Page", command=(fun () -> dispatch (SetRootPageKind MasterDetail)))
                                  View.Button(text = "Infinite scrolling ListView", command=(fun () -> dispatch (SetRootPageKind InfiniteScrollList)))
+                                 View.Button(text = "Message dialog", command=(fun () -> dispatch ShowMessage))
                             ]))
                      .ToolbarItems([View.ToolbarItem(text="About", command=(fun () -> dispatch (SetRootPageKind (Choice true))))] )
                   if showAbout then 

--- a/Samples/TicTacToe/TicTacToe/TicTacToe.fs
+++ b/Samples/TicTacToe/TicTacToe/TicTacToe.fs
@@ -211,7 +211,7 @@ module App =
     // this dependency out to allow unit testing of the 'update' function. 
 
     let gameOver msg =
-        Application.Current.MainPage.DisplayAlert("Game over", msg, "OK") |> ignore
+        View.displayAlert "Game over" msg "OK" |> ignore
 
     let program = 
         Program.mkSimple init (update gameOver) view


### PR DESCRIPTION
Added simple helpers around methods `Page.DisplayAlert` and `Page.DisplayActionSheet`.
Those are statically accessible through `Application.Current.MainPage`, just like the TicTacToe sample does.

But accessing the MainPage is confusing when doing full-elmish, as we don't have direct access to UI elements most of the times.