### PR TITLE
Fixed module name for SkiaSharp

### DIFF
--- a/extensions/SkiaSharp/SkiaSharp.fs
+++ b/extensions/SkiaSharp/SkiaSharp.fs
@@ -2,7 +2,7 @@
 namespace Elmish.XamarinForms.DynamicViews 
 
 [<AutoOpen>]
-module MapsExtension = 
+module SkiaSharpExtension = 
 
     open Elmish.XamarinForms.DynamicViews
 


### PR DESCRIPTION
Quick fix on the module name of the SkiaSharp extension.
Mostly for coherence.